### PR TITLE
Add support for showing class names in report

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ Show line rate as specific column.
 
 Show branch rate as specific column.
 
+### `show_class_names`
+
+Show class names instead of file names.
+
 ## Example usage
 
 ```yaml

--- a/action.yml
+++ b/action.yml
@@ -23,6 +23,10 @@ inputs:
     description: 'Show branch rate as specific column.'
     required: true
     default: false
+  show_class_names:
+    description: 'Show class names instead of file names.'
+    required: true
+    default: false
 runs:
   using: 'node12'
   main: 'index.js'

--- a/src/action.js
+++ b/src/action.js
@@ -23,17 +23,25 @@ async function action(payload) {
   const minimumCoverage = parseInt(
     core.getInput("minimum_coverage", { required: true })
   );
+  const showClassNames = JSON.parse(
+    core.getInput("show_class_names", { required: true })
+  );
   const report = await processCoverage(path, { skipCovered });
   await addComment(pullRequest, report, {
     minimumCoverage,
     showLine,
-    showBranch
+    showBranch,
+    showClassNames
   });
 }
 
 function markdownReport(report, options) {
-  const { minimumCoverage = 100, showLine = false, showBranch = false } =
-    options || {};
+  const {
+    minimumCoverage = 100,
+    showLine = false,
+    showBranch = false,
+    showClassNames = false
+  } = options || {};
   const status = total =>
     total >= minimumCoverage ? ":white_check_mark:" : ":x:";
   // Setup files
@@ -43,7 +51,7 @@ function markdownReport(report, options) {
     const fileLines = Math.round(file.line);
     const fileBranch = Math.round(file.branch);
     files.push([
-      file.filename,
+      showClassNames ? file.name : file.filename,
       `\`${fileTotal}%\``,
       showLine ? `\`${fileLines}%\`` : undefined,
       showBranch ? `\`${fileBranch}%\`` : undefined,

--- a/src/action.test.js
+++ b/src/action.test.js
@@ -7,8 +7,8 @@ const dummyReport = {
   line: 77.5,
   branch: 0,
   files: [
-    { filename: "foo.py", total: 80, line: 80, branch: 0 },
-    { filename: "bar.py", total: 75, line: 80, branch: 0 }
+    { name: "ClassFoo", filename: "foo.py", total: 80, line: 80, branch: 0 },
+    { name: "ClassBar", filename: "bar.py", total: 75, line: 80, branch: 0 }
   ]
 };
 
@@ -24,6 +24,7 @@ test("action", async () => {
   process.env["INPUT_SHOW_BRANCH"] = "false";
   process.env["INPUT_SHOW_LINE"] = "false";
   process.env["INPUT_MINIMUM_COVERAGE"] = "100";
+  process.env["INPUT_SHOW_CLASS_NAMES"] = "false";
   const prNumber = 1;
   nock("https://api.github.com")
     .post(`/repos/${owner}/${repo}/issues/${prNumber}/comments`)
@@ -79,6 +80,15 @@ _Minimum allowed coverage is \`70%\`_`);
 | bar.py | \`75%\` | :x: |
 
 _Minimum allowed coverage is \`80%\`_`);
+
+  expect(markdownReport(dummyReport, { showClassNames: true }))
+    .toBe(`| File | Coverage |   |
+| - | :-: | :-: |
+| **All files** | \`78%\` | :x: |
+| ClassFoo | \`80%\` | :x: |
+| ClassBar | \`75%\` | :x: |
+
+_Minimum allowed coverage is \`100%\`_`);
 });
 
 test("addComment", async () => {


### PR DESCRIPTION
One can now configure the action to show class names instead of file names by setting `show_class_names: true`

Fixes #2 