### PR TITLE
Add support for only reporting coverage on changed files

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ Show branch rate as specific column.
 
 Show class names instead of file names.
 
+### `only_changed_files`
+
+Only show coverage for changed files.
+
 ## Example usage
 
 ```yaml

--- a/action.yml
+++ b/action.yml
@@ -27,6 +27,10 @@ inputs:
     description: 'Show class names instead of file names.'
     required: true
     default: false
+  only_changed_files:
+    description: 'Only show coverage for changed files.'
+    required: true
+    default: false
 runs:
   using: 'node12'
   main: 'index.js'


### PR DESCRIPTION
This can be turned on by setting `only_changed_files: true`