### PR TITLE
fix: add missing report_name in `action.yml`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -43,6 +43,10 @@ inputs:
     description: 'Pull request number associated with the report. This property should be used when workflow trigger is different than pull_request.'
     required: false
     default: ''
+  report_name:
+    description: 'Use a unique name for the report and comment.'
+    required: false
+    default: ''
 runs:
   using: 'node12'
   main: 'dist/index.js'


### PR DESCRIPTION
Usage of this action with `report_name` input give following warning:
```
Warning: Unexpected input(s) 'report_name', valid inputs are ['repo_token', 'path', 'skip_covered', 'minimum_coverage', 'show_line', 'show_branch', 'show_class_names', 'show_missing', 'show_missing_max_length', 'only_changed_files', 'pull_request_number']
```

This request add missing input definition to `action.yml` manifest.