### PR TITLE
Fix broken config parser

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -18198,10 +18198,8 @@ async function action(payload) {
   const linkMissingLines = JSON.parse(
     core.getInput("link_missing_lines", { required: false }) || "false"
   );
-  const linkMissingLinesSourceDir = JSON.parse(
-    core.getInput("link_missing_lines_source_dir", { required: false }) ||
-      "null"
-  );
+  const linkMissingLinesSourceDir =
+    core.getInput("link_missing_lines_source_dir", { required: false }) || null;
   const onlyChangedFiles = JSON.parse(
     core.getInput("only_changed_files", { required: true })
   );

--- a/src/action.js
+++ b/src/action.js
@@ -44,10 +44,8 @@ async function action(payload) {
   const linkMissingLines = JSON.parse(
     core.getInput("link_missing_lines", { required: false }) || "false"
   );
-  const linkMissingLinesSourceDir = JSON.parse(
-    core.getInput("link_missing_lines_source_dir", { required: false }) ||
-      "null"
-  );
+  const linkMissingLinesSourceDir =
+    core.getInput("link_missing_lines_source_dir", { required: false }) || null;
   const onlyChangedFiles = JSON.parse(
     core.getInput("only_changed_files", { required: true })
   );


### PR DESCRIPTION
Setting `link_missing_lines_source_dir` currently yields: `Error: Unexpected token s in JSON at position 0`.