### PR TITLE
feature: Add ability to fail for individual file below threshold

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,11 @@ The minimum allowed coverage percentage as an integer.
 
 ### `fail_below_threshold`
 
-Fail the action when the minimum coverage was not met.
+Fail the action when the minimum coverage is not met for the entire report.
+
+### `fail_for_individual_file_below_threshold`
+
+Fail the action when the specified minimum coverage is not met for any file.
 
 ### `show_line`
 

--- a/action.yml
+++ b/action.yml
@@ -16,7 +16,11 @@ inputs:
     description: 'Minimum allowed coverage percentage as an integer.'
     required: true
   fail_below_threshold:
-    description: 'Fail the action when the minimum coverage was not met.'
+    description: 'Fail the action when the minimum coverage is not met for the entire report.'
+    required: false
+    default: false
+  fail_for_individual_file_below_threshold:
+    description: 'Fail the action when the specified minimum coverage is not met for any file.'
     required: false
     default: false
   show_line:

--- a/src/action.js
+++ b/src/action.js
@@ -29,10 +29,6 @@ async function action(payload) {
   const failBelowThreshold = JSON.parse(
     core.getInput("fail_below_threshold", { required: false }) || "false"
   );
-  const minimumCoverageForEachFile = parseInt(
-    core.getInput("minimum_coverage_for_each_file", { required: false })
-  );
-
   const failForIndividualFileBelowThreshold = JSON.parse(
     core.getInput("fail_for_individual_file_below_threshold", {
       required: false,


### PR DESCRIPTION
I found that once the entire codebase is above a certain percentage, it's hard to enforce it if other files are below the threshold. I'd like it so if any file has an X next to it, it will fail the build.