### PR TITLE
Add more context to fail_below_threshold documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ The minimum allowed coverage percentage as an integer.
 
 ### `fail_below_threshold`
 
-Fail the action when the minimum coverage was not met.
+Fail the action when the minimum coverage was not met. Defaults to `false`.
 
 ### `show_line`
 


### PR DESCRIPTION
This extra comment indicates the value expected to consumers of the action