### PR TITLE
Fix common prefix

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -39031,11 +39031,11 @@ function markdownReport(reports, commit, options) {
   } = options || {};
   const status = (total) =>
     total >= minimumCoverage ? ":white_check_mark:" : ":x:";
-  // Setup files
-  const files = [];
   let output = "";
   for (const report of reports) {
     const folder = reports.length <= 1 ? "" : ` ${report.folder}`;
+    // Setup files
+    const files = [];
     for (const file of report.files.filter(
       (file) => filteredFiles == null || filteredFiles.includes(file.filename),
     )) {
@@ -39215,6 +39215,7 @@ const fs = (__nccwpck_require__(7147).promises);
 const xml2js = __nccwpck_require__(6189);
 const util = __nccwpck_require__(3837);
 const glob = __nccwpck_require__(8252);
+const pathLib = __nccwpck_require__(1017);
 const parseString = util.promisify(xml2js.parseString);
 
 /**
@@ -39250,13 +39251,12 @@ async function readCoverageFromFile(path, options) {
 }
 
 function trimFolder(path, positionOfFirstDiff) {
-  const lastFolder = path.lastIndexOf("/") + 1;
-  if (positionOfFirstDiff >= lastFolder) {
-    return path.substr(lastFolder);
+  const pathParts = path.split(pathLib.sep);
+
+  if (positionOfFirstDiff >= pathParts.length - 1) {
+    return pathParts[pathParts.length-1];
   } else {
-    const startOffset = Math.min(positionOfFirstDiff - 1, lastFolder);
-    const length = path.length - startOffset - lastFolder - 2; // remove filename
-    return path.substr(startOffset, length);
+    return pathLib.join(...pathParts.slice(positionOfFirstDiff, pathParts.length-1));
   }
 }
 
@@ -39389,20 +39389,20 @@ function partitionLines(statements, lines) {
  * @returns number
  */
 function longestCommonPrefix(paths) {
-  let prefix = "";
   if (paths === null || paths.length === 0) return 0;
 
-  for (let i = 0; i < paths[0].length; i++) {
-    const char = paths[0][i]; // loop through all characters of the very first string.
+  const pathParts = paths.map((p) => p.split(pathLib.sep));
+
+  for (let i = 0; i < pathParts[0].length; i++) {
+    const pi = pathParts[0][i]; // loop through all parts of first path
 
     for (let j = 1; j < paths.length; j++) {
-      // loop through all other strings in the array
-      if (paths[j][i] !== char) return prefix.length;
+      // loop through all other paths in array
+      if (pathParts[j][i] !== pi) return i;
     }
-    prefix = prefix + char;
   }
 
-  return prefix.length;
+  return pathParts[0].length;
 }
 
 module.exports = {

--- a/src/action.js
+++ b/src/action.js
@@ -164,11 +164,11 @@ function markdownReport(reports, commit, options) {
   } = options || {};
   const status = (total) =>
     total >= minimumCoverage ? ":white_check_mark:" : ":x:";
-  // Setup files
-  const files = [];
   let output = "";
   for (const report of reports) {
     const folder = reports.length <= 1 ? "" : ` ${report.folder}`;
+    // Setup files
+    const files = [];
     for (const file of report.files.filter(
       (file) => filteredFiles == null || filteredFiles.includes(file.filename),
     )) {

--- a/src/cobertura.js
+++ b/src/cobertura.js
@@ -2,6 +2,7 @@ const fs = require("fs").promises;
 const xml2js = require("xml2js");
 const util = require("util");
 const glob = require("glob-promise");
+const pathLib = require("path");
 const parseString = util.promisify(xml2js.parseString);
 
 /**
@@ -37,13 +38,12 @@ async function readCoverageFromFile(path, options) {
 }
 
 function trimFolder(path, positionOfFirstDiff) {
-  const lastFolder = path.lastIndexOf("/") + 1;
-  if (positionOfFirstDiff >= lastFolder) {
-    return path.substr(lastFolder);
+  const pathParts = path.split(pathLib.sep);
+
+  if (positionOfFirstDiff >= pathParts.length - 1) {
+    return pathParts[pathParts.length-1];
   } else {
-    const startOffset = Math.min(positionOfFirstDiff - 1, lastFolder);
-    const length = path.length - startOffset - lastFolder - 2; // remove filename
-    return path.substr(startOffset, length);
+    return pathLib.join(...pathParts.slice(positionOfFirstDiff, pathParts.length-1));
   }
 }
 
@@ -176,20 +176,20 @@ function partitionLines(statements, lines) {
  * @returns number
  */
 function longestCommonPrefix(paths) {
-  let prefix = "";
   if (paths === null || paths.length === 0) return 0;
 
-  for (let i = 0; i < paths[0].length; i++) {
-    const char = paths[0][i]; // loop through all characters of the very first string.
+  const pathParts = paths.map((p) => p.split(pathLib.sep));
+
+  for (let i = 0; i < pathParts[0].length; i++) {
+    const pi = pathParts[0][i]; // loop through all parts of first path
 
     for (let j = 1; j < paths.length; j++) {
-      // loop through all other strings in the array
-      if (paths[j][i] !== char) return prefix.length;
+      // loop through all other paths in array
+      if (pathParts[j][i] !== pi) return i;
     }
-    prefix = prefix + char;
   }
 
-  return prefix.length;
+  return pathParts[0].length;
 }
 
 module.exports = {

--- a/src/cobertura.test.js
+++ b/src/cobertura.test.js
@@ -263,11 +263,12 @@ test("processCoverage(test-missing-lines.xml, {skipCovered: true})", async () =>
 });
 
 test("trimFolder", () => {
-  expect(trimFolder("/a/b/c/file.xml", 7)).toBe("file.xml");
-  expect(trimFolder("/a/b/c/file.xml", 3)).toBe("/b/c");
+  expect(trimFolder("/a/b/c/file.xml", 4)).toBe("file.xml");
+  expect(trimFolder("/a/b/c/file.xml", 2)).toBe("b/c");
 });
 
 test("longestCommonPrefix", () => {
   expect(longestCommonPrefix(null)).toBe(0);
   expect(longestCommonPrefix([])).toBe(0);
+  expect(longestCommonPrefix(['a/b-c', 'a/b-d'])).toBe(1)
 });


### PR DESCRIPTION
The old algorithm for determining the common prefix and trimming the folder name didn't work correctly when the glob result contained folder names that had the same prefix but then diverged. It then outputted just an empty folder name.

E.g.: 
`a/b-c/coverage.xml` and `a/b-d/coverage.xml` would yield empty folder names for the separate paths.

I've instead opted to operate on path fragment level and comparing the folder names. This might subtly change the folder names the action outputs, e.g. no leading slash.

This also fixes #68.